### PR TITLE
Added Identifiable Adapter to allow deserialization of FileRecord/FileAdapter to fields of that Types

### DIFF
--- a/src/main/java/com/stratumn/sdk/Sdk.java
+++ b/src/main/java/com/stratumn/sdk/Sdk.java
@@ -40,12 +40,15 @@ import com.stratumn.chainscript.utils.CryptoUtils;
 import com.stratumn.chainscript.utils.JsonHelper;
 import com.stratumn.sdk.adapters.ByteBufferGsonAdapter;
 import com.stratumn.sdk.adapters.FileWrapperGsonAdapter;
+import com.stratumn.sdk.adapters.IdentifiableGsonAdapter;
 import com.stratumn.sdk.adapters.PathGsonAdapter;
+import com.stratumn.sdk.adapters.RuntimeTypeAdapterFactory;
 import com.stratumn.sdk.graph.GraphQl;
 import com.stratumn.sdk.model.api.GraphResponse;
 import com.stratumn.sdk.model.client.PrivateKeySecret;
 import com.stratumn.sdk.model.client.Secret;
 import com.stratumn.sdk.model.file.MediaRecord;
+import com.stratumn.sdk.model.misc.Identifiable;
 import com.stratumn.sdk.model.misc.Property;
 import com.stratumn.sdk.model.sdk.SdkConfig;
 import com.stratumn.sdk.model.sdk.SdkOptions;
@@ -100,6 +103,8 @@ public class Sdk<TState> implements ISdk<TState> {
       JsonHelper.registerTypeHierarchyAdapter(ByteBuffer.class, new ByteBufferGsonAdapter());
       JsonHelper.registerTypeHierarchyAdapter(Path.class, new PathGsonAdapter());
       JsonHelper.registerTypeAdapter(FileWrapper.class, new FileWrapperGsonAdapter());
+      JsonHelper.registerTypeAdapter(Identifiable.class, new IdentifiableGsonAdapter());
+     
    }
 
    /**

--- a/src/main/java/com/stratumn/sdk/Sdk.java
+++ b/src/main/java/com/stratumn/sdk/Sdk.java
@@ -15,8 +15,6 @@ See the License for the specific language governing permissions and
 */
 package com.stratumn.sdk;
 
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.security.PrivateKey;
@@ -42,7 +40,6 @@ import com.stratumn.sdk.adapters.ByteBufferGsonAdapter;
 import com.stratumn.sdk.adapters.FileWrapperGsonAdapter;
 import com.stratumn.sdk.adapters.IdentifiableGsonAdapter;
 import com.stratumn.sdk.adapters.PathGsonAdapter;
-import com.stratumn.sdk.adapters.RuntimeTypeAdapterFactory;
 import com.stratumn.sdk.graph.GraphQl;
 import com.stratumn.sdk.model.api.GraphResponse;
 import com.stratumn.sdk.model.client.PrivateKeySecret;

--- a/src/main/java/com/stratumn/sdk/adapters/IdentifiableGsonAdapter.java
+++ b/src/main/java/com/stratumn/sdk/adapters/IdentifiableGsonAdapter.java
@@ -1,0 +1,41 @@
+package com.stratumn.sdk.adapters;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.stratumn.sdk.FileRecord;
+import com.stratumn.sdk.FileWrapper;
+import com.stratumn.sdk.model.misc.Identifiable;
+
+/***
+ *  Enables deserialization of Identifiable declared field.
+ */
+public class IdentifiableGsonAdapter  implements JsonDeserializer<Identifiable>, JsonSerializer<Identifiable>     {
+
+     
+    @Override
+    public Identifiable deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+           if(json != null && json instanceof JsonObject) 
+              if(((JsonObject) json).get("digest") != null)
+                 return context.deserialize(json, FileRecord.class);
+              else 
+                 return context.deserialize(json, FileWrapper.class);
+          return null; 
+          
+    }
+
+   @Override
+   public JsonElement serialize(Identifiable src, Type typeOfSrc, JsonSerializationContext context)
+   {
+      JsonElement json = context.serialize(src);
+      return json;
+       
+   }
+ 
+}

--- a/src/test/java/com/stratumn/sdk/TestSdkPojo.java
+++ b/src/test/java/com/stratumn/sdk/TestSdkPojo.java
@@ -78,6 +78,20 @@ class OperationClass{
    public String eta;
 }
 
+
+  class Step
+{
+
+    public StepData data;
+}
+
+  class StepData
+{
+    public Identifiable[] stp_form_section;
+}
+
+
+
 public class TestSdkPojo
 {
 
@@ -228,7 +242,8 @@ public class TestSdkPojo
    //used to pass the trace from one test method to another
    private TraceState<StateExample, SomeClass> someTraceState;
    private TraceState<StateExample,OperationClass> anotherTraceState;
-
+    private TraceState<StateExample, Step> uploadState;
+    
    @Test
    public void newTraceTest()
    {
@@ -264,23 +279,19 @@ public class TestSdkPojo
       try
       {
          Sdk<StateExample> sdk = getSdk();
-         Map<String, Object> dataMap = new HashMap<String, Object>();
-         dataMap.put("weight", "123");
-         dataMap.put("valid", true);
-         dataMap.put("operators", new String[]{"1", "2" });
-         dataMap.put("operation", "my new operation 1");
-//         dataMap.put("Certificate" , FileWrapper.fromFilePath(Paths.get("src/test/resources/stratumn.png")));
-         dataMap.put("Certificate2" , FileWrapper.fromFilePath(Paths.get("src/test/resources/TestFile1.txt")));
-          dataMap.put("Certificates",new Identifiable[] {
-                         FileWrapper.fromFilePath(Paths.get("src/test/resources/TestFile1.txt")) 
-         } ); 
-        //quickly convert existing map to object but the object can be created any way
-          SomeClass data= JsonHelper.mapToObject(dataMap, SomeClass.class);
-         NewTraceInput<SomeClass> newTraceInput = new NewTraceInput<SomeClass>(FORM_ID, data);
+        
+         Step s = new Step();
+         s.data = new StepData();
+ 
+         //This fails on Identifiable deserialzation 
+         s.data.stp_form_section =new Identifiable[] { FileWrapper.fromFilePath(Paths.get("src/test/resources/TestFile1.txt")) };
 
-         TraceState<StateExample, SomeClass> state = sdk.newTrace(newTraceInput);
+         NewTraceInput<Step> newTraceInput = new NewTraceInput<Step>(FORM_ID, s);
+ 
+
+         TraceState<StateExample, Step> state = sdk.newTrace(newTraceInput);
          assertNotNull(state.getTraceId());
-         someTraceState = state;
+        
       }
       catch(Exception ex)
       {
@@ -462,15 +473,15 @@ public class TestSdkPojo
    {
        try
       {
-          TraceState<StateExample, SomeClass> state;
+          TraceState<StateExample, Step> state;
          try
          {
-            state = getSdk().getTraceState(new GetTraceStateInput("dee0dd04-5d58-4c4e-a72d-a759e37ae337"));
+            state = getSdk().getTraceState(new GetTraceStateInput("5cd59d4c-0b59-4cfc-9cbe-4b6aa2ad0cc4"));
          }
          catch(Exception e)
          {  //trace not found
             newTraceUploadTest();
-            state = someTraceState;
+            state = uploadState;
          }
 
          Object dataWithRecords = state.getHeadLink().formData();
@@ -478,7 +489,8 @@ public class TestSdkPojo
          Map<String, Property<FileWrapper>> fileWrappers = Helpers.extractFileWrappers(dataWithFiles);
          
          for ( Property<FileWrapper> fileWrapperProp: fileWrappers.values())
-         {  writeFileToDisk(fileWrapperProp.getValue());
+         {  
+            writeFileToDisk(fileWrapperProp.getValue());
             //assert files are equal
          }
       }
@@ -489,7 +501,11 @@ public class TestSdkPojo
       }
    }
    
-   
+   /***
+    * Writes the files to the output folder
+    * @param fWrapper
+    * @throws TraceSdkException
+    */
    private void writeFileToDisk(FileWrapper fWrapper) throws TraceSdkException
    { 
       
@@ -517,6 +533,9 @@ public class TestSdkPojo
         throw new TraceSdkException(e);
      }
    }
+   
+   
  
+
 
 }


### PR DESCRIPTION
Added a TypeAdapter for Identifiable to check if the returned object has a "digest" and deserialize it as  FileRecord otherwise it will deserialize it as FileAdapter.  In turn FileAdapter implemented already handles deserialization to one of the subtypes. 
+ Fixing invalid import