### PR TITLE
Add config ID to links (ALP-150)

### DIFF
--- a/src/main/java/com/stratumn/sdk/Client.java
+++ b/src/main/java/com/stratumn/sdk/Client.java
@@ -622,9 +622,7 @@ public class Client {
 
       HttpEntity<R> entity = new HttpEntity<R>(requestBody, headers);
 
-      // System.out.println (JsonHelper.toJson(entity));
       ResponseEntity<T> resp = restTemplate.postForEntity(url, entity, tClass);
-
       return resp;
 
    }
@@ -691,6 +689,8 @@ public class Client {
       }
 
       private void traceResponse(ClientHttpResponse response) throws IOException {
+         HttpStatus statusCode = response.getStatusCode();
+
          StringBuilder inputStringBuilder = new StringBuilder();
          BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody(), "UTF-8"));
          String line = bufferedReader.readLine();
@@ -700,7 +700,7 @@ public class Client {
             line = bufferedReader.readLine();
          }
          System.out.println("============================response begin==============================================");
-         System.out.println("Status code  : " + response.getStatusCode());
+         System.out.println("Status code  : " + statusCode);
          System.out.println("Status text  : " + response.getStatusText());
          System.out.println("Headers      : " + response.getHeaders());
          System.out.println("Response body: " + inputStringBuilder.toString());

--- a/src/main/java/com/stratumn/sdk/TraceLinkBuilder.java
+++ b/src/main/java/com/stratumn/sdk/TraceLinkBuilder.java
@@ -80,6 +80,9 @@ public class TraceLinkBuilder<TLinkData> extends LinkBuilder {
 		// set the created at timestamp
 		this.metadata = new TraceLinkMetaData();
 		this.metadata.setCreatedAt(new Date());
+		// this.metadata.setConfigId(cfg.getConfigId());
+		this.metadata.setConfigId("1");
+		;
 
 		// if parent link was provided set the parent hash and priority
 		if (this.parentLink != null) {
@@ -287,6 +290,17 @@ public class TraceLinkBuilder<TLinkData> extends LinkBuilder {
 	 */
 	public TraceLinkBuilder<TLinkData> withCreatedBy(String userId) {
 		this.metadata.setCreatedById(userId);
+		return this;
+	}
+
+	/**
+	 * To set the metadata createdById.
+	 *
+	 * @param configId the workflow config ID
+	 * @return
+	 */
+	public TraceLinkBuilder<TLinkData> withConfigId(String configId) {
+		this.metadata.setConfigId(configId);
 		return this;
 	}
 

--- a/src/main/java/com/stratumn/sdk/TraceLinkBuilder.java
+++ b/src/main/java/com/stratumn/sdk/TraceLinkBuilder.java
@@ -80,8 +80,7 @@ public class TraceLinkBuilder<TLinkData> extends LinkBuilder {
 		// set the created at timestamp
 		this.metadata = new TraceLinkMetaData();
 		this.metadata.setCreatedAt(new Date());
-		// this.metadata.setConfigId(cfg.getConfigId());
-		this.metadata.setConfigId("1");
+		this.metadata.setConfigId(cfg.getConfigId());
 		;
 
 		// if parent link was provided set the parent hash and priority

--- a/src/main/java/com/stratumn/sdk/model/sdk/SdkConfig.java
+++ b/src/main/java/com/stratumn/sdk/model/sdk/SdkConfig.java
@@ -23,6 +23,11 @@ public class SdkConfig {
 	 * The workflow id
 	 */
 	private String workflowId;
+
+	/**
+	 * The workflow config id
+	 */
+	private String configId;
 	/**
 	 * The user id
 	 */
@@ -48,9 +53,18 @@ public class SdkConfig {
 	public SdkConfig() {
 	}
 
-	public SdkConfig(String workflowId, String userId, String accountId, String groupId, String ownerId,
+	public String getConfigId() {
+		return configId;
+	}
+
+	public void setConfigId(String configId) {
+		this.configId = configId;
+	}
+
+	public SdkConfig(String workflowId, String configId, String userId, String accountId, String groupId, String ownerId,
 			PrivateKey signingPrivateKey) {
 		this.workflowId = workflowId;
+		this.configId = configId;
 		this.userId = userId;
 		this.accountId = accountId;
 		this.groupId = groupId;

--- a/src/main/java/com/stratumn/sdk/model/trace/TraceLinkBuilderConfig.java
+++ b/src/main/java/com/stratumn/sdk/model/trace/TraceLinkBuilderConfig.java
@@ -21,11 +21,20 @@ package com.stratumn.sdk.model.trace;
 public class TraceLinkBuilderConfig<TLinkData> {
 
 	private String workflowId;
+	private String configId;
 	private ITraceLink<TLinkData> parentLink;
 	private boolean enableDebuging = false;
 
 	public TraceLinkBuilderConfig() {
 
+	}
+
+	public String getConfigId() {
+		return configId;
+	}
+
+	public void setConfigId(String configId) {
+		this.configId = configId;
 	}
 
 	public boolean isEnableDebuging() {
@@ -36,8 +45,9 @@ public class TraceLinkBuilderConfig<TLinkData> {
 		this.enableDebuging = enableDebuging;
 	}
 
-	public TraceLinkBuilderConfig(String workflowId, ITraceLink<TLinkData> parentLink) {
+	public TraceLinkBuilderConfig(String workflowId, String configId, ITraceLink<TLinkData> parentLink) {
 		this.workflowId = workflowId;
+		this.setConfigId(configId);
 		this.parentLink = parentLink;
 	}
 

--- a/src/main/java/com/stratumn/sdk/model/trace/TraceLinkMetaData.java
+++ b/src/main/java/com/stratumn/sdk/model/trace/TraceLinkMetaData.java
@@ -16,12 +16,14 @@ See the License for the specific language governing permissions and
 package com.stratumn.sdk.model.trace;
 
 import java.util.Date;
+
 /**
  * The link metadata
  */
 public class TraceLinkMetaData {
 
 	private String ownerId;
+	private String configId;
 	private String groupId;
 	private String formId;
 	private String lastFormId;
@@ -30,18 +32,17 @@ public class TraceLinkMetaData {
 	private String set;
 	private String[] inputs;
 
-	 
-	public TraceLinkMetaData(  )
-    {
-      super(); 
-    }
+	public TraceLinkMetaData() {
+		super();
+	}
 
-
-
-   TraceLinkMetaData(String ownerId, String groupId, String formId, String lastFormId, Date createdAt,
+	TraceLinkMetaData(String ownerId, String configId, String groupId, String formId, String lastFormId, Date createdAt,
 			String createdById, String[] inputs) throws IllegalArgumentException {
 		if (ownerId == null) {
 			throw new IllegalArgumentException("ownerId cannot be null");
+		}
+		if (configId == null) {
+			throw new IllegalArgumentException("configId cannot be null");
 		}
 		if (groupId == null) {
 			throw new IllegalArgumentException("groupId cannot be null");
@@ -61,8 +62,9 @@ public class TraceLinkMetaData {
 		if (inputs == null) {
 			throw new IllegalArgumentException("inputs cannot be null");
 		}
-	 
+
 		this.ownerId = ownerId;
+		this.configId = configId;
 		this.groupId = groupId;
 		this.formId = formId;
 		this.lastFormId = lastFormId;
@@ -77,6 +79,14 @@ public class TraceLinkMetaData {
 
 	public void setOwnerId(String ownerId) {
 		this.ownerId = ownerId;
+	}
+
+	public String getConfigId() {
+		return this.configId;
+	}
+
+	public void setConfigId(String configId) {
+		this.configId = configId;
 	}
 
 	public String getGroupId() {
@@ -126,6 +136,7 @@ public class TraceLinkMetaData {
 	public void setInputs(String[] inputs) {
 		this.inputs = inputs;
 	}
+
 	public String getSet() {
 		return set;
 	}
@@ -133,8 +144,5 @@ public class TraceLinkMetaData {
 	public void setSet(String set) {
 		this.set = set;
 	}
-
-
-	 
 
 }

--- a/src/main/resources/graphql/Queries/Config.graphql
+++ b/src/main/resources/graphql/Queries/Config.graphql
@@ -17,6 +17,9 @@ query ConfigQuery($workflowId: BigInt!) {
     }
   }
   workflow: workflowByRowId(rowId: $workflowId) {
+    config {
+      id: rowId
+    }
     groups {
       nodes {
         groupId: rowId


### PR DESCRIPTION
1. get the active wf config ID in the sdk config
2. add it to the link metadata
3. if the API returns an error because of the config ID being deprecated, update the config ID and retry.
4. In case something unexpected happens and the backend say that wf config is deprecated again, do not retry. This will allow us to avoid infinite loops in case of bad backend implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-java/15)
<!-- Reviewable:end -->
