### PR TITLE
Fix blob encryption

### DIFF
--- a/src/main/java/com/stratumn/sdk/FileBlobWrapper.java
+++ b/src/main/java/com/stratumn/sdk/FileBlobWrapper.java
@@ -23,34 +23,35 @@ import com.stratumn.sdk.model.file.FileInfo;
  * The implementation of a FileWrapper using the blob and info to represent it.
  */
 public class FileBlobWrapper extends FileWrapper {
-	
-   
-    private ByteBuffer blob;
-	private FileInfo fileInfo;
 
-	public FileBlobWrapper(ByteBuffer blob, FileInfo fileInfo) {
-		 super(fileInfo.getKey()==null || fileInfo.getKey() == "", fileInfo.getKey());
-		this.blob = blob;
-		this.fileInfo = fileInfo;
-	}
+  private ByteBuffer blob;
+  private FileInfo fileInfo;
 
-	public FileInfo info() {
-		return this.fileInfo;
-	}
+  public FileBlobWrapper(ByteBuffer blob, FileInfo fileInfo) {
+    super(false, fileInfo.getKey());
+    this.blob = blob;
+    this.fileInfo = fileInfo;
+  }
 
+  protected FileBlobWrapper(ByteBuffer blob, FileInfo fileInfo, boolean disableEncryption) {
+    super(disableEncryption, fileInfo.getKey());
+    this.blob = blob;
+    this.fileInfo = fileInfo;
+  }
 
+  public FileInfo info() {
+    return this.fileInfo;
+  }
 
-   @Override
-   public ByteBuffer encryptedData() throws TraceSdkException
-   { 
-            return super.encryptData(this.blob);
-      
-   }
+  @Override
+  public ByteBuffer encryptedData() throws TraceSdkException {
+    return super.encryptData(this.blob);
 
-   @Override
-   public  ByteBuffer  decryptedData() throws TraceSdkException
-   {
-            return super.decryptData(this.blob);
-   }
+  }
+
+  @Override
+  public ByteBuffer decryptedData() throws TraceSdkException {
+    return super.decryptData(this.blob);
+  }
 
 }

--- a/src/main/java/com/stratumn/sdk/FileRecord.java
+++ b/src/main/java/com/stratumn/sdk/FileRecord.java
@@ -15,6 +15,11 @@ See the License for the specific language governing permissions and
 */
 package com.stratumn.sdk;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map.Entry;
+
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.stratumn.canonicaljson.CanonicalJson;
 import com.stratumn.chainscript.utils.JsonHelper;
@@ -136,7 +141,7 @@ public class FileRecord implements Identifiable {
             if (json != null) {
                // attempt to generate FileRecord from json.
                json = removeAdditionalFields(json);
-               
+
                Object ob = JsonHelper.fromJson(json, FileRecord.class);
                String json2 = JsonHelper.toCanonicalJson(ob);
                if (json2.equalsIgnoreCase(json))
@@ -148,14 +153,18 @@ public class FileRecord implements Identifiable {
       return isFileRecord;
    }
 
-   // Since we do a canonicalized JSON string comparison to check if the object is a 
-   // FileRecord above, we need to remove the additional fields that can be added
+   // Since we do a canonicalized JSON string comparison to check if the object is
+   // a FileRecord above, we need to remove the additional fields that can be added
    // by the media API.
    private static String removeAdditionalFields(String json) {
+      List<String> recordFields = Arrays.asList(new String[] { "id", "key", "digest", "name", "mimetype", "size" });
       JsonObject o = JsonHelper.fromJson(json, JsonObject.class);
 
-      o.remove("createdAt");
-      o.remove("id");
+      for (Entry<String, JsonElement> e : o.entrySet()) {
+         if (!recordFields.contains(e.getKey())) {
+            o.remove(e.getKey());
+         }
+      }
 
       return JsonHelper.toJson(o);
 

--- a/src/main/java/com/stratumn/sdk/Sdk.java
+++ b/src/main/java/com/stratumn/sdk/Sdk.java
@@ -46,6 +46,7 @@ import com.stratumn.sdk.graph.GraphQl;
 import com.stratumn.sdk.model.api.GraphResponse;
 import com.stratumn.sdk.model.client.PrivateKeySecret;
 import com.stratumn.sdk.model.client.Secret;
+import com.stratumn.sdk.model.file.FileInfo;
 import com.stratumn.sdk.model.file.MediaRecord;
 import com.stratumn.sdk.model.misc.Identifiable;
 import com.stratumn.sdk.model.misc.Property;
@@ -496,8 +497,9 @@ public class Sdk<TState> implements ISdk<TState> {
       for (Entry<String, Property<FileRecord>> fileRecordElt : idToFileRecordMap.entrySet()) {
          FileRecord fileRecord = fileRecordElt.getValue().getValue();
          ByteBuffer file = client.downloadFile(fileRecord);
-         fileWrapperList.add(
-               fileRecordElt.getValue().transform((T) -> FileWrapper.fromFileBlob(file, fileRecord.getFileInfo())));
+         FileInfo info = fileRecord.getFileInfo();
+         fileWrapperList.add(fileRecordElt.getValue()
+               .transform((T) -> new FileBlobWrapper(file, info, info.getKey() == null || info.getKey() == "")));
       }
       return fileWrapperList;
    }


### PR DESCRIPTION
when initiating FileBlobWrapper, we explicitly pass the file info. The same class is used everywhere, which is confusing because it also contains the user file encryption key.
When the user inits a FileBlobWrapper,, he should be able to pass a null key to delegate the creation of a random key to the SDK (same as in the FilePathWrapper). Right now, when he passes the null key, the decryption is disabled.

Note: I has to create an other (internal) constructor for FileBlobWrapper where I can explicitly say if encryption is disabled or not so that we can still download non unencrypted files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-java/16)
<!-- Reviewable:end -->
