### PR TITLE
BTA-391: Remove link and group owner

### DIFF
--- a/.project
+++ b/.project
@@ -31,4 +31,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1603963981399</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.stratumn</groupId>
   <artifactId>sdk</artifactId>
-  <version>0.1.2-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <name>Stratumn JAVA SDK</name>
   <description>Stratumn services SDK</description>
   <url>https://github.com/stratumn/sdk-java</url>

--- a/src/main/java/com/stratumn/sdk/Sdk.java
+++ b/src/main/java/com/stratumn/sdk/Sdk.java
@@ -149,13 +149,22 @@ public class Sdk<TState> implements ISdk<TState> {
          myAccounts.add(element.getAsJsonObject().get("accountId").toString());
       }
 
+      // get all the groups I belong to
+      // i.e. where I belong to one of the account members
       List<JsonElement> myGroups = new ArrayList<JsonElement>();
-      // get all the groups that are owned by one of my accounts
+
       Iterator<JsonElement> iteratorGNodes = groupNodes.getAsJsonArray().iterator();
       while (iteratorGNodes.hasNext()) {
          JsonElement group = iteratorGNodes.next();
-         if (myAccounts.contains(group.getAsJsonObject().get("accountId").toString())) {
-            myGroups.add(group);
+
+         Iterator<JsonElement> members = group.getAsJsonObject().get("members").getAsJsonObject().get("nodes")
+               .getAsJsonArray().iterator();
+         while (members.hasNext()) {
+            JsonElement member = members.next();
+            if (myAccounts.contains(member.getAsJsonObject().get("accountId").toString())) {
+               myGroups.add(group);
+               break;
+            }
          }
       }
 
@@ -172,7 +181,6 @@ public class Sdk<TState> implements ISdk<TState> {
       // extract info from my only group
       String groupId = myGroups.get(0).getAsJsonObject().get("groupId").getAsString();
 
-      String ownerId = myGroups.get(0).getAsJsonObject().get("accountId").getAsString();
       PrivateKey signingPrivateKey = null;
       try {
          if (Secret.isPrivateKeySecret(opts.getSecret())) {
@@ -195,7 +203,7 @@ public class Sdk<TState> implements ISdk<TState> {
          throw new TraceSdkException("Security key error", ex);
       }
 
-      this.config = new SdkConfig(workflowId, configId, userId, accountId, groupId, ownerId, signingPrivateKey);
+      this.config = new SdkConfig(workflowId, configId, userId, accountId, groupId, signingPrivateKey);
 
       // return the new config
       return this.config;
@@ -654,7 +662,6 @@ public class Sdk<TState> implements ISdk<TState> {
       String workflowId = sdkConfig.getWorkflowId();
       String configId = sdkConfig.getConfigId();
       String userId = sdkConfig.getUserId();
-      String ownerId = sdkConfig.getOwnerId();
       String groupId = sdkConfig.getGroupId();
       // upload files and transform data
       this.uploadFilesInLinkData(data);
@@ -675,8 +682,6 @@ public class Sdk<TState> implements ISdk<TState> {
 
       // this is an attestation
       linkBuilder.forAttestation(action, data)
-            // add owner info
-            .withOwner(ownerId)
             // add group info
             .withGroup(groupId)
             // add creator info
@@ -726,7 +731,6 @@ public class Sdk<TState> implements ISdk<TState> {
       String workflowId = sdkConfig.getWorkflowId();
       String configId = sdkConfig.getConfigId();
       String userId = sdkConfig.getUserId();
-      String ownerId = sdkConfig.getOwnerId();
       String groupId = sdkConfig.getGroupId();
 
       TraceLinkBuilderConfig<TLinkData> cfg = new TraceLinkBuilderConfig<TLinkData>();
@@ -744,8 +748,6 @@ public class Sdk<TState> implements ISdk<TState> {
 
          // this is an attestation
          linkBuilder.forAcceptTransfer(data)
-               // add owner info
-               .withOwner(ownerId)
                // add group info
                .withGroup(groupId)
                // add creator info
@@ -796,7 +798,6 @@ public class Sdk<TState> implements ISdk<TState> {
       String workflowId = sdkConfig.getWorkflowId();
       String configId = sdkConfig.getConfigId();
       String userId = sdkConfig.getUserId();
-      String ownerId = sdkConfig.getOwnerId();
       String groupId = sdkConfig.getGroupId();
 
       TraceLinkBuilderConfig<TLinkData> cfg = new TraceLinkBuilderConfig<TLinkData>();
@@ -813,8 +814,6 @@ public class Sdk<TState> implements ISdk<TState> {
 
          // this is a push transfer
          linkBuilder.forRejectTransfer(data)
-               // add owner info
-               .withOwner(ownerId)
                // add group info
                .withGroup(groupId)
                // add creator info
@@ -919,7 +918,6 @@ public class Sdk<TState> implements ISdk<TState> {
       String workflowId = sdkConfig.getWorkflowId();
       String configId = sdkConfig.getConfigId();
       String userId = sdkConfig.getUserId();
-      String ownerId = sdkConfig.getOwnerId();
       String groupId = sdkConfig.getGroupId();
       // upload files and transform data
       this.uploadFilesInLinkData(data);
@@ -938,8 +936,6 @@ public class Sdk<TState> implements ISdk<TState> {
 
          // this is an attestation
          linkBuilder.forAttestation(action, data)
-               // add owner info
-               .withOwner(ownerId)
                // add group info
                .withGroup(groupId)
                // add creator info

--- a/src/main/java/com/stratumn/sdk/TraceLink.java
+++ b/src/main/java/com/stratumn/sdk/TraceLink.java
@@ -68,10 +68,6 @@ public class TraceLink<TLinkData> extends Link implements ITraceLink<TLinkData> 
     return this.metadata().getCreatedAt();
   }
 
-  public Account owner() throws ChainscriptException {
-    return new Account(this.metadata().getOwnerId());
-  }
-
   /**
    * The id of the group under which the trace is.
    * 

--- a/src/main/java/com/stratumn/sdk/TraceLinkBuilder.java
+++ b/src/main/java/com/stratumn/sdk/TraceLinkBuilder.java
@@ -147,7 +147,7 @@ public class TraceLinkBuilder<TLinkData> extends LinkBuilder {
 
 	/**
 	 * Helper method used to configure a link for an attestation. User must still
-	 * set owner, group and createdBy separately.
+	 * set group and createdBy separately.
 	 *
 	 * @param action the action key used for the attestation
 	 * @param action the name of the action associated with this form
@@ -163,8 +163,8 @@ public class TraceLinkBuilder<TLinkData> extends LinkBuilder {
 
 	/**
 	 * Helper method used for transfer of ownership requests (push and pull). Note
-	 * that owner and group are calculated from parent link. Parent link must have
-	 * been provided!
+	 * that group is calculated from parent link. Parent link must have been
+	 * provided!
 	 *
 	 * @param to     the group to which the transfer is made for
 	 * @param action the action (_PUSH_OWNERSHIP_ or _PULL_OWNERSHIP_)
@@ -176,8 +176,7 @@ public class TraceLinkBuilder<TLinkData> extends LinkBuilder {
 	public TraceLinkBuilder<TLinkData> forTransferRequest(String to, TraceActionType action, TraceLinkType type,
 			TLinkData data) throws ChainscriptException, TraceSdkException {
 		TraceLink<TLinkData> parent = this.getParentLink();
-		this.withOwner(parent.owner().getAccount()).withHashedData(data).withGroup(parent.group())
-				.withAction(action.toString()).withProcessState(type.toString());
+		this.withHashedData(data).withGroup(parent.group()).withAction(action.toString()).withProcessState(type.toString());
 		this.metadata.setInputs(new String[] { to });
 		this.metadata.setLastFormId(parent.form() != null ? parent.form() : parent.lastForm());
 		return this;
@@ -210,8 +209,8 @@ public class TraceLinkBuilder<TLinkData> extends LinkBuilder {
 	}
 
 	/**
-	 * Helper method used to cancel a transfer request. Note that owner and group
-	 * are calculated from parent link. Parent link must have been provided!
+	 * Helper method used to cancel a transfer request. Note that group is
+	 * calculated from parent link. Parent link must have been provided!
 	 *
 	 * @param data the optional data
 	 * @throws TraceSdkException
@@ -221,14 +220,13 @@ public class TraceLinkBuilder<TLinkData> extends LinkBuilder {
 		TraceLink<TLinkData> parent = this.getParentLink();
 		String action = TraceActionType.CANCEL_TRANSFER.toString();
 		String type = TraceLinkType.OWNED.toString();
-		this.withOwner(parent.owner().getAccount()).withGroup(parent.group()).withHashedData(data).withAction(action)
-				.withProcessState(type);
+		this.withGroup(parent.group()).withHashedData(data).withAction(action).withProcessState(type);
 		return this;
 	}
 
 	/**
-	 * Helper method used to reject a transfer request. Note that owner and group
-	 * are calculated from parent link. Parent link must have been provided!
+	 * Helper method used to reject a transfer request. Note that group is
+	 * calculated from parent link. Parent link must have been provided!
 	 *
 	 * @param data the optional data
 	 * @throws TraceSdkException
@@ -239,14 +237,13 @@ public class TraceLinkBuilder<TLinkData> extends LinkBuilder {
 		String action = TraceActionType.REJECT_TRANSFER.toString();
 		String type = TraceLinkType.OWNED.toString();
 
-		this.withOwner(parent.owner().getAccount()).withGroup(parent.group()).withHashedData(data).withAction(action)
-				.withProcessState(type);
+		this.withGroup(parent.group()).withHashedData(data).withAction(action).withProcessState(type);
 		return this;
 	}
 
 	/**
 	 * Helper method used to accept a transfer request. Parent link must have been
-	 * provided! User must still set owner, group and createdBy separately.
+	 * provided! User must still set group and createdBy separately.
 	 *
 	 * @param data the optional data
 	 * @throws TraceSdkException
@@ -258,16 +255,6 @@ public class TraceLinkBuilder<TLinkData> extends LinkBuilder {
 		String type = TraceLinkType.OWNED.toString();
 
 		this.withHashedData(data).withAction(action).withProcessState(type);
-		return this;
-	}
-
-	/**
-	 * To set the metadata ownerId.
-	 *
-	 * @param ownerId the owner id
-	 */
-	public TraceLinkBuilder<TLinkData> withOwner(String ownerId) {
-		this.metadata.setOwnerId(ownerId);
 		return this;
 	}
 

--- a/src/main/java/com/stratumn/sdk/model/sdk/SdkConfig.java
+++ b/src/main/java/com/stratumn/sdk/model/sdk/SdkConfig.java
@@ -42,10 +42,6 @@ public class SdkConfig {
 	private String groupId;
 
 	/**
-	 * The owner id
-	 */
-	private String ownerId;
-	/**
 	 * The private key used for signing links
 	 */
 	private PrivateKey signingPrivateKey;
@@ -61,14 +57,13 @@ public class SdkConfig {
 		this.configId = configId;
 	}
 
-	public SdkConfig(String workflowId, String configId, String userId, String accountId, String groupId, String ownerId,
+	public SdkConfig(String workflowId, String configId, String userId, String accountId, String groupId,
 			PrivateKey signingPrivateKey) {
 		this.workflowId = workflowId;
 		this.configId = configId;
 		this.userId = userId;
 		this.accountId = accountId;
 		this.groupId = groupId;
-		this.ownerId = ownerId;
 		this.signingPrivateKey = signingPrivateKey;
 	}
 
@@ -102,14 +97,6 @@ public class SdkConfig {
 
 	public void setGroupId(String groupId) {
 		this.groupId = groupId;
-	}
-
-	public String getOwnerId() {
-		return ownerId;
-	}
-
-	public void setOwnerId(String ownerId) {
-		this.ownerId = ownerId;
 	}
 
 	public PrivateKey getSigningPrivateKey() {

--- a/src/main/java/com/stratumn/sdk/model/trace/ITraceLink.java
+++ b/src/main/java/com/stratumn/sdk/model/trace/ITraceLink.java
@@ -5,24 +5,31 @@ import java.util.Date;
 
 import com.stratumn.chainscript.ChainscriptException;
 import com.stratumn.chainscript.ILink;
+
 /**
- * Interface extending a Chainscript Link
- * with common trace methods.
+ * Interface extending a Chainscript Link with common trace methods.
  */
-public interface ITraceLink<TLinkData>  extends ILink
-{
-   public TLinkData formData() throws ChainscriptException ;
-   public String traceId()throws ChainscriptException  ;
-   public String workflowId()throws ChainscriptException ;
-   public TraceLinkType type()throws ChainscriptException ; 
-   public Account createdBy()throws ChainscriptException  ;
-   public Date createdAt()throws ChainscriptException  ;
-   public Account owner() throws ChainscriptException  ;
-   public String  group()throws ChainscriptException  ;
-   public String form()throws ChainscriptException ;
-   public String lastForm()throws ChainscriptException  ;
-   public String[] inputs() throws ChainscriptException ; 
-   public TraceLinkMetaData metadata( )throws ChainscriptException ;
-   
-   
+public interface ITraceLink<TLinkData> extends ILink {
+   public TLinkData formData() throws ChainscriptException;
+
+   public String traceId() throws ChainscriptException;
+
+   public String workflowId() throws ChainscriptException;
+
+   public TraceLinkType type() throws ChainscriptException;
+
+   public Account createdBy() throws ChainscriptException;
+
+   public Date createdAt() throws ChainscriptException;
+
+   public String group() throws ChainscriptException;
+
+   public String form() throws ChainscriptException;
+
+   public String lastForm() throws ChainscriptException;
+
+   public String[] inputs() throws ChainscriptException;
+
+   public TraceLinkMetaData metadata() throws ChainscriptException;
+
 }

--- a/src/main/java/com/stratumn/sdk/model/trace/TraceLinkMetaData.java
+++ b/src/main/java/com/stratumn/sdk/model/trace/TraceLinkMetaData.java
@@ -22,7 +22,6 @@ import java.util.Date;
  */
 public class TraceLinkMetaData {
 
-	private String ownerId;
 	private String configId;
 	private String groupId;
 	private String formId;
@@ -36,11 +35,8 @@ public class TraceLinkMetaData {
 		super();
 	}
 
-	TraceLinkMetaData(String ownerId, String configId, String groupId, String formId, String lastFormId, Date createdAt,
+	TraceLinkMetaData(String configId, String groupId, String formId, String lastFormId, Date createdAt,
 			String createdById, String[] inputs) throws IllegalArgumentException {
-		if (ownerId == null) {
-			throw new IllegalArgumentException("ownerId cannot be null");
-		}
 		if (configId == null) {
 			throw new IllegalArgumentException("configId cannot be null");
 		}
@@ -63,7 +59,6 @@ public class TraceLinkMetaData {
 			throw new IllegalArgumentException("inputs cannot be null");
 		}
 
-		this.ownerId = ownerId;
 		this.configId = configId;
 		this.groupId = groupId;
 		this.formId = formId;
@@ -71,14 +66,6 @@ public class TraceLinkMetaData {
 		this.createdAt = createdAt;
 		this.createdById = createdById;
 		this.inputs = inputs;
-	}
-
-	public String getOwnerId() {
-		return this.ownerId;
-	}
-
-	public void setOwnerId(String ownerId) {
-		this.ownerId = ownerId;
 	}
 
 	public String getConfigId() {

--- a/src/main/resources/graphql/Queries/Config.graphql
+++ b/src/main/resources/graphql/Queries/Config.graphql
@@ -23,7 +23,11 @@ query ConfigQuery($workflowId: BigInt!) {
     groups {
       nodes {
         groupId: rowId
-        accountId: ownerId
+        members {
+          nodes {
+            accountId
+          }
+        }
       }
     }
   }

--- a/src/test/java/com/stratumn/sdk/TestSdk.java
+++ b/src/test/java/com/stratumn/sdk/TestSdk.java
@@ -262,9 +262,8 @@ public class TestSdk {
       try {
          newTraceTest();
          assertNotNull(someTraceState);
-         Map<String, Object> data = new HashMap<String, Object>(
-               Collections.singletonMap("why", "because im testing the pushTrace"));
-         PushTransferInput<Object> push = new PushTransferInput<Object>(OTHER_GROUP, data, someTraceState.getTraceId());
+         PushTransferInput<Object> push = new PushTransferInput<Object>(OTHER_GROUP, new Object(),
+               someTraceState.getTraceId());
 
          someTraceState = getSdk().pushTrace(push);
          // System.out.println("test pushTrace " + gson.toJson(someTraceState));

--- a/src/test/java/com/stratumn/sdk/TestSdkPojo.java
+++ b/src/test/java/com/stratumn/sdk/TestSdkPojo.java
@@ -222,7 +222,6 @@ public class TestSdkPojo {
 
    // used to pass the trace from one test method to another
    private TraceState<StateExample, SomeClass> someTraceState;
-   private TraceState<StateExample, OperationClass> anotherTraceState;
    private TraceState<StateExample, Step> uploadState;
 
    @Test
@@ -294,13 +293,10 @@ public class TestSdkPojo {
       try {
          newTraceTest();
          assertNotNull(someTraceState);
-         OperationClass data;
-         String json = "{ operation: \"XYZ shipment departed port for ABC\"," + "    destination: \"ABC\", "
-               + "    customsCheck: true, " + "    eta: \"2019-07-02T12:00:00.000Z\"" + "  }";
-         data = JsonHelper.objectToObject(json, OperationClass.class);
-         PushTransferInput<OperationClass> push = new PushTransferInput<OperationClass>(OTHER_GROUP, data,
+         PushTransferInput<Object> push = new PushTransferInput<Object>(OTHER_GROUP, new Object(),
                someTraceState.getTraceId());
-         anotherTraceState = getSdk().pushTrace(push);
+
+         getSdk().pushTrace(push);
          // System.out.println("test pushTrace " + gson.toJson(someTraceState));
          assertNotNull(push.getTraceId());
       } catch (Exception ex) {
@@ -326,7 +322,6 @@ public class TestSdkPojo {
          TransferResponseInput<SomeClass> trInput = new TransferResponseInput<SomeClass>(null,
                someTraceState.getTraceId());
          TraceState<StateExample, SomeClass> stateAccept = getOtherGroupSdk().acceptTransfer(trInput);
-         // System.out.println("Accept Transfer:" + "\r\n" + stateAccept);
          assertNotNull(stateAccept.getTraceId());
       } catch (Exception ex) {
          ex.printStackTrace();


### PR DESCRIPTION
- remove mentions to link owner. At this point, owner_id should not be required by the API anymore
- remove usage of group.owner
- use group members instead to find the group which the SDK user is part of

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-java/17)
<!-- Reviewable:end -->
