### PR TITLE
Handle bots with multiple groups [BTA-924]

### DIFF
--- a/RunTest.cmd
+++ b/RunTest.cmd
@@ -73,7 +73,7 @@ set CLASSPATH="!CLASSPATH!"
 @REM echo !CLASSPATH! 
   
 Echo Executing SDK Test 
-%JAVA_EXE%  -cp !CLASSPATH!;.\target\sdk-1.0.jar;.\target\test-classes  com.stratumn.sdk.TestSdkPojo
+%JAVA_EXE%  -cp !CLASSPATH!;.\target\sdk-1.0.jar;.\target\test-classes  com.stratumn.sdk.TestSdk
 
 Goto success
   

--- a/src/main/java/com/stratumn/sdk/Sdk.java
+++ b/src/main/java/com/stratumn/sdk/Sdk.java
@@ -177,7 +177,7 @@ public class Sdk<TState> implements ISdk<TState> {
             }
          }
 
-         // // there must be at least one group!
+         // there must be at least one group!
          if (myGroups.size() == 0) {
             throw new TraceSdkException("No group to choose from.");
          }
@@ -209,9 +209,8 @@ public class Sdk<TState> implements ISdk<TState> {
       }
 
       // sets the group id in any case
-      if (null != this.opts.getGroupLabel()
-            && null != this.config.getGroupLabelToIdMap().get(this.opts.getGroupLabel())) {
-         this.config.setGroupId(this.config.getGroupLabelToIdMap().get(this.opts.getGroupLabel()));
+      if (null != this.opts.getGroupLabel()) {
+         this.config.setGroupLabel(this.opts.getGroupLabel());
       }
 
       // return the new config

--- a/src/main/java/com/stratumn/sdk/Sdk.java
+++ b/src/main/java/com/stratumn/sdk/Sdk.java
@@ -121,97 +121,98 @@ public class Sdk<TState> implements ISdk<TState> {
     * @return the Sdk config object
     */
    private SdkConfig getConfig(boolean forceUpdate) throws TraceSdkException {
-      // if the config already exists use it!
-      if (this.config != null && !forceUpdate)
-         return this.config;
+      // update the config if doesn't exist or force
+      if (this.config == null || forceUpdate) {
+         String workflowId = this.opts.getWorkflowId();
+         // execute graphql query
+         GraphResponse response = this.client.graphql(GraphQl.Query.QUERY_CONFIG,
+               Collections.singletonMap("workflowId", workflowId), null, GraphResponse.class);
+         if (response.hasErrors())
+            throw new TraceSdkException(Arrays.asList(response.getErrors()).toString());
+         JsonElement groupNodes = response.getData("workflow.groups.nodes");
+         if (groupNodes == null)
+            throw new TraceSdkException("Workflow.groups object not found:\n" + response.toString());
 
-      String workflowId = this.opts.getWorkflowId();
-      // execute graphql query
-      GraphResponse response = this.client.graphql(GraphQl.Query.QUERY_CONFIG,
-            Collections.singletonMap("workflowId", workflowId), null, GraphResponse.class);
-      if (response.hasErrors())
-         throw new TraceSdkException(Arrays.asList(response.getErrors()).toString());
-      JsonElement groupNodes = response.getData("workflow.groups.nodes");
-      if (groupNodes == null)
-         throw new TraceSdkException("Workflow.groups object not found:\n" + response.toString());
+         String accountId = response.getData("account.accountId").getAsString();
 
-      String accountId = response.getData("account.accountId").getAsString();
+         String configId = response.getData("workflow.config.id").getAsString();
 
-      String configId = response.getData("workflow.config.id").getAsString();
+         JsonElement userMemberOf = response.getData("account.user.memberOf.nodes");
+         JsonElement botTeams = response.getData("account.bot.teams.nodes");
 
-      JsonElement userMemberOf = response.getData("account.user.memberOf.nodes");
-      JsonElement botTeams = response.getData("account.bot.teams.nodes");
-
-      List<String> myAccounts = new ArrayList<String>();
-      Iterator<JsonElement> iteratorNodes = null;
-      // get all the account ids I am a member of
-      if (null != userMemberOf) {
-         iteratorNodes = userMemberOf.getAsJsonArray().iterator();
-      } else if (null != botTeams) {
-         iteratorNodes = botTeams.getAsJsonArray().iterator();
-      }
-      if (null != iteratorNodes) {
-         while (iteratorNodes.hasNext()) {
-            JsonElement element = iteratorNodes.next();
-            myAccounts.add(element.getAsJsonObject().get("accountId").toString());
+         List<String> myAccounts = new ArrayList<String>();
+         Iterator<JsonElement> iteratorNodes = null;
+         // get all the account ids I am a member of
+         if (null != userMemberOf) {
+            iteratorNodes = userMemberOf.getAsJsonArray().iterator();
+         } else if (null != botTeams) {
+            iteratorNodes = botTeams.getAsJsonArray().iterator();
          }
-      }
-
-      // get all the groups I belong to
-      // i.e. where I belong to one of the account members
-      List<JsonElement> myGroups = new ArrayList<JsonElement>();
-
-      Iterator<JsonElement> iteratorGNodes = groupNodes.getAsJsonArray().iterator();
-      while (iteratorGNodes.hasNext()) {
-         JsonElement group = iteratorGNodes.next();
-
-         Iterator<JsonElement> members = group.getAsJsonObject().get("members").getAsJsonObject().get("nodes")
-               .getAsJsonArray().iterator();
-         while (members.hasNext()) {
-            JsonElement member = members.next();
-            if (myAccounts.contains(member.getAsJsonObject().get("accountId").toString())) {
-               myGroups.add(group);
-               break;
+         if (null != iteratorNodes) {
+            while (iteratorNodes.hasNext()) {
+               JsonElement element = iteratorNodes.next();
+               myAccounts.add(element.getAsJsonObject().get("accountId").toString());
             }
          }
-      }
 
-      // there must be at most one group!
-      if (myGroups.size() > 1) {
-         throw new TraceSdkException("More than one group to choose from.");
-      }
+         // get all the groups I belong to
+         // i.e. where I belong to one of the account members
+         List<JsonElement> myGroups = new ArrayList<JsonElement>();
+         Map<String, String> groupLabelToIdMap = new HashMap<String, String>();
 
-      // // there must be at least one group!
-      if (myGroups.size() == 0) {
-         throw new TraceSdkException("No group to choose from.");
-      }
+         Iterator<JsonElement> iteratorGNodes = groupNodes.getAsJsonArray().iterator();
+         while (iteratorGNodes.hasNext()) {
+            JsonElement group = iteratorGNodes.next();
 
-      // extract info from my only group
-      String groupId = myGroups.get(0).getAsJsonObject().get("groupId").getAsString();
-
-      PrivateKey signingPrivateKey = null;
-      try {
-         if (Secret.isPrivateKeySecret(opts.getSecret())) {
-            // if the secret is a PrivateKeySecret, use it!
-            final String privateKey = ((PrivateKeySecret) opts.getSecret()).getPrivateKey();
-            signingPrivateKey = CryptoUtils.decodePrivateKey(privateKey);
-         } else {
-            JsonElement privateKeyElt = response.getData("account.signingKey.privateKey");
-            JsonObject privateKey = privateKeyElt.getAsJsonObject();
-            Boolean passwordProtected = privateKey.get("passwordProtected").getAsBoolean();
-            String decrypted = privateKey.get("decrypted").getAsString();
-            if (!passwordProtected)
-               // otherwise use the key from the response
-               // if it's not password protected!
-               signingPrivateKey = CryptoUtils.decodePrivateKey(decrypted);
-            else
-               throw new TraceSdkException("Cannot get signing private key");
+            Iterator<JsonElement> members = group.getAsJsonObject().get("members").getAsJsonObject().get("nodes")
+                  .getAsJsonArray().iterator();
+            while (members.hasNext()) {
+               JsonElement member = members.next();
+               if (myAccounts.contains(member.getAsJsonObject().get("accountId").toString())) {
+                  myGroups.add(group);
+                  groupLabelToIdMap.put(group.getAsJsonObject().get("label").getAsString(),
+                        group.getAsJsonObject().get("groupId").getAsString());
+                  break;
+               }
+            }
          }
-      } catch (InvalidKeySpecException ex) {
-         throw new TraceSdkException("Security key error", ex);
+
+         // // there must be at least one group!
+         if (myGroups.size() == 0) {
+            throw new TraceSdkException("No group to choose from.");
+         }
+
+         PrivateKey signingPrivateKey = null;
+         try {
+            if (Secret.isPrivateKeySecret(opts.getSecret())) {
+               // if the secret is a PrivateKeySecret, use it!
+               final String privateKey = ((PrivateKeySecret) opts.getSecret()).getPrivateKey();
+               signingPrivateKey = CryptoUtils.decodePrivateKey(privateKey);
+            } else {
+               JsonElement privateKeyElt = response.getData("account.signingKey.privateKey");
+               JsonObject privateKey = privateKeyElt.getAsJsonObject();
+               Boolean passwordProtected = privateKey.get("passwordProtected").getAsBoolean();
+               String decrypted = privateKey.get("decrypted").getAsString();
+               if (!passwordProtected)
+                  // otherwise use the key from the response
+                  // if it's not password protected!
+                  signingPrivateKey = CryptoUtils.decodePrivateKey(decrypted);
+               else
+                  throw new TraceSdkException("Cannot get signing private key");
+            }
+         } catch (InvalidKeySpecException ex) {
+            throw new TraceSdkException("Security key error", ex);
+         }
+
+         this.config = new SdkConfig(workflowId, configId, accountId, groupLabelToIdMap, signingPrivateKey);
+
       }
 
-      this.config = new SdkConfig(workflowId, configId, accountId, groupId, signingPrivateKey);
+      // sets the group id in any case
+      if (null != this.opts.getGroupLabel()
+            && null != this.config.getGroupLabelToIdMap().get(this.opts.getGroupLabel())) {
+         this.config.setGroupId(this.config.getGroupLabelToIdMap().get(this.opts.getGroupLabel()));
+      }
 
       // return the new config
       return this.config;
@@ -220,6 +221,11 @@ public class Sdk<TState> implements ISdk<TState> {
 
    private SdkConfig getConfig() throws TraceSdkException {
       return this.getConfig(false);
+   }
+
+   public Sdk<TState> withGroupLabel(String groupLabel) {
+      this.opts.setGroupLabel(groupLabel);
+      return this;
    }
 
    /***
@@ -252,7 +258,7 @@ public class Sdk<TState> implements ISdk<TState> {
                ? JsonHelper.fromJson(trace.get("state").getAsJsonObject().get("data"), classOfTState)
                : (TState) trace.get("state").getAsJsonObject().get("data");
          traceState = new TraceState<TState, TLinkData>(headLink.traceId(), headLink, headLink.createdAt(),
-               headLink.createdBy(), tState, tags.toArray(new String[tags.size()]));
+               headLink.createdBy(), tState, tags.toArray(new String[tags.size()]), headLink.group());
       } catch (ChainscriptException e) {
          throw new TraceSdkException("Error constructing traceState ", e);
       }
@@ -429,7 +435,6 @@ public class Sdk<TState> implements ISdk<TState> {
          TracesState<TState, TLinkData> tracesList = new TracesState<TState, TLinkData>();
          tracesList.setTraces(traces);
 
-         tracesList.setTraces(traces);
          tracesList.setTotalCount(totalCount);
          tracesList.setInfo(gson.fromJson(info, Info.class));
          return tracesList;
@@ -664,12 +669,14 @@ public class Sdk<TState> implements ISdk<TState> {
       // extract info from input
       String action = input.getAction();
       TLinkData data = input.getData();
+      String groupLabel = input.getGroupLabel();
 
+      // Set the group label if it is set
       SdkConfig sdkConfig = this.getConfig();
 
       String workflowId = sdkConfig.getWorkflowId();
       String configId = sdkConfig.getConfigId();
-      String groupId = sdkConfig.getGroupId();
+      String groupId = sdkConfig.getGroupId(groupLabel);
       String accountId = sdkConfig.getAccountId();
       // upload files and transform data
       this.uploadFilesInLinkData(data);
@@ -733,13 +740,14 @@ public class Sdk<TState> implements ISdk<TState> {
 
       // extract info from input
       TLinkData data = input.getData();
+      String groupLabel = input.getGroupLabel();
 
       SdkConfig sdkConfig = this.getConfig();
 
       String workflowId = sdkConfig.getWorkflowId();
       String configId = sdkConfig.getConfigId();
       String accountId = sdkConfig.getAccountId();
-      String groupId = sdkConfig.getGroupId();
+      String groupId = sdkConfig.getGroupId(groupLabel);
 
       TraceLinkBuilderConfig<TLinkData> cfg = new TraceLinkBuilderConfig<TLinkData>();
       // provide workflow id
@@ -800,13 +808,14 @@ public class Sdk<TState> implements ISdk<TState> {
       TraceLink<TLinkData> parentLink = this.getHeadLink(headLinkInput);
 
       TLinkData data = input.getData();
+      String groupLabel = input.getGroupLabel();
 
       SdkConfig sdkConfig = this.getConfig();
 
       String workflowId = sdkConfig.getWorkflowId();
       String configId = sdkConfig.getConfigId();
       String accountId = sdkConfig.getAccountId();
-      String groupId = sdkConfig.getGroupId();
+      String groupId = sdkConfig.getGroupId(groupLabel);
 
       TraceLinkBuilderConfig<TLinkData> cfg = new TraceLinkBuilderConfig<TLinkData>();
       // provide workflow id
@@ -920,13 +929,14 @@ public class Sdk<TState> implements ISdk<TState> {
       // extract info from input
       String action = input.getAction();
       TLinkData data = input.getData();
+      String groupLabel = input.getGroupLabel();
 
       SdkConfig sdkConfig = this.getConfig();
 
       String workflowId = sdkConfig.getWorkflowId();
       String configId = sdkConfig.getConfigId();
       String accountId = sdkConfig.getAccountId();
-      String groupId = sdkConfig.getGroupId();
+      String groupId = sdkConfig.getGroupId(groupLabel);
       // upload files and transform data
       this.uploadFilesInLinkData(data);
 
@@ -1078,7 +1088,6 @@ public class Sdk<TState> implements ISdk<TState> {
       TracesState<TState, TLinkData> tracesList = new TracesState<TState, TLinkData>();
       tracesList.setTraces(traces);
 
-      tracesList.setTraces(traces);
       tracesList.setTotalCount(traceResponse.get("totalCount").getAsInt());
       tracesList.setInfo(gson.fromJson(traceResponse.get("info").getAsJsonObject(), Info.class));
       return tracesList;

--- a/src/main/java/com/stratumn/sdk/model/sdk/SdkConfig.java
+++ b/src/main/java/com/stratumn/sdk/model/sdk/SdkConfig.java
@@ -37,7 +37,7 @@ public class SdkConfig {
 	/**
 	 * The group id
 	 */
-	private String groupId;
+	private String groupLabel;
 	/**
 	 * Map label to group id
 	 */
@@ -92,8 +92,12 @@ public class SdkConfig {
 		return this.getGroupIdByLabel(groupLabel);
 	}
 
-	public void setGroupId(String groupId) {
-		this.groupId = groupId;
+	public String getGroupLabel() {
+		return this.groupLabel;
+	}
+
+	public void setGroupLabel(String groupLabel) {
+		this.groupLabel = groupLabel;
 	}
 
 	private String getGroupIdByLabel(String groupLabelParam) throws TraceSdkException {
@@ -105,8 +109,8 @@ public class SdkConfig {
 					resultGroupId = groupLabelToIdMap.get(groupLabelToIdMap.keySet().toArray()[0]);
 				} else if (groupLabelToIdMap.size() > 1) {
 					// Last check if groupId has been set manually
-					if (null != this.groupId) {
-						resultGroupId = this.groupId;
+					if (null != this.getGroupLabel() && null != groupLabelToIdMap.get(this.getGroupLabel())) {
+						resultGroupId = groupLabelToIdMap.get(this.getGroupLabel());
 					} else {
 						throw new TraceSdkException(
 								"Multiple groups to select from, please specify the group label you wish to perform the action with.");

--- a/src/main/java/com/stratumn/sdk/model/sdk/SdkOptions.java
+++ b/src/main/java/com/stratumn/sdk/model/sdk/SdkOptions.java
@@ -17,22 +17,35 @@ package com.stratumn.sdk.model.sdk;
 
 import com.stratumn.sdk.model.client.*;
 
-public class SdkOptions extends ClientOptions{
+public class SdkOptions extends ClientOptions {
   private String workflowId;
- 
+  private String groupLabel;
 
   public SdkOptions(String workflowId, Secret secret) {
-      super(null, secret);
-      this.workflowId = workflowId;
+    super(null, secret);
+    this.workflowId = workflowId;
   }
-   
-	public String getWorkflowId() {
-		return this.workflowId;
-	}
 
-	public void setWorkflowId(String workflowId) {
-		this.workflowId = workflowId;
-	}
-	
+  public SdkOptions(String workflowId, Secret secret, String groupLabel) {
+    super(null, secret);
+    this.workflowId = workflowId;
+    this.groupLabel = groupLabel;
+  }
 
-} 
+  public String getWorkflowId() {
+    return this.workflowId;
+  }
+
+  public void setWorkflowId(String workflowId) {
+    this.workflowId = workflowId;
+  }
+
+  public String getGroupLabel() {
+    return this.groupLabel;
+  }
+
+  public void setGroupLabel(String groupLabel) {
+    this.groupLabel = groupLabel;
+  }
+
+}

--- a/src/main/java/com/stratumn/sdk/model/trace/AppendLinkInput.java
+++ b/src/main/java/com/stratumn/sdk/model/trace/AppendLinkInput.java
@@ -29,6 +29,7 @@ public class AppendLinkInput<TLinkData> {
   private TLinkData data;
   private String traceId;
   private ITraceLink<TLinkData> prevLink;
+  private String groupLabel;
 
   public AppendLinkInput(String action, TLinkData data, String traceId) throws IllegalArgumentException {
     if (action == null) {
@@ -87,6 +88,14 @@ public class AppendLinkInput<TLinkData> {
 
   public void setPrevLink(ITraceLink<TLinkData> prevLink) {
     this.prevLink = prevLink;
+  }
+
+  public String getGroupLabel() {
+    return this.groupLabel;
+  }
+
+  public void setGroupLabel(String groupLabel) {
+    this.groupLabel = groupLabel;
   }
 
 }

--- a/src/main/java/com/stratumn/sdk/model/trace/NewTraceInput.java
+++ b/src/main/java/com/stratumn/sdk/model/trace/NewTraceInput.java
@@ -17,12 +17,13 @@ package com.stratumn.sdk.model.trace;
 
 /**
  * Interface used as argument to create a new trace. User must provide the form
- * id to use and the form data.
+ * id to use, the form data and the group's label.
  */
 public class NewTraceInput<TLinkData> {
 
   private String action;
   private TLinkData data;
+  private String groupLabel;
 
   public NewTraceInput(String action, TLinkData data) throws IllegalArgumentException {
     if (action == null) {
@@ -30,6 +31,15 @@ public class NewTraceInput<TLinkData> {
     }
     this.action = action;
     this.data = data;
+  }
+
+  public NewTraceInput(String action, TLinkData data, String groupLabel) throws IllegalArgumentException {
+    if (action == null) {
+      throw new IllegalArgumentException("action cannot be null in NewTraceInput");
+    }
+    this.action = action;
+    this.data = data;
+    this.groupLabel = groupLabel;
   }
 
   public String getFormId() {
@@ -54,6 +64,14 @@ public class NewTraceInput<TLinkData> {
 
   public void setData(TLinkData data) {
     this.data = data;
+  }
+
+  public String getGroupLabel() {
+    return this.groupLabel;
+  }
+
+  public void setGroupLabel(String groupLabel) {
+    this.groupLabel = groupLabel;
   }
 
 }

--- a/src/main/java/com/stratumn/sdk/model/trace/TraceState.java
+++ b/src/main/java/com/stratumn/sdk/model/trace/TraceState.java
@@ -17,30 +17,26 @@ package com.stratumn.sdk.model.trace;
 
 import java.util.Arrays;
 import java.util.Date;
+
 /**
- * The state of trace is composed of:
- * - the trace id
- * - the link hash of the head of the trace
- * - the date at which it was last updated
- * - the person who last updated it
- * - some abstract data validated against a predefined schema
- * - the tags of the trace
+ * The state of trace is composed of: - the trace id - the link hash of the head
+ * of the trace - the date at which it was last updated - the person who last
+ * updated it - some abstract data validated against a predefined schema - the
+ * tags of the trace
  */
-public class TraceState<TState, TLinkData>
-{
+public class TraceState<TState, TLinkData> {
 
    private String traceId;
    private ITraceLink<TLinkData> headLink;
    private Date updatedAt;
    private Account updatedBy;
+   private String updatedByGroupId;
    private TState data;
    private String[] tags;
 
-   public TraceState(String traceId, ITraceLink<TLinkData> headLink, Date updatedAt, Account updatedBy, TState data, String[] tags)
-      throws IllegalArgumentException
-   {
-      if(traceId == null)
-      {
+   public TraceState(String traceId, ITraceLink<TLinkData> headLink, Date updatedAt, Account updatedBy, TState data,
+         String[] tags, String updatedByGroupId) throws IllegalArgumentException {
+      if (traceId == null) {
          throw new IllegalArgumentException("traceId cannot be null in a TraceState object");
       }
 
@@ -50,75 +46,70 @@ public class TraceState<TState, TLinkData>
       this.updatedBy = updatedBy;
       this.data = data;
       this.tags = tags;
+      this.updatedByGroupId = updatedByGroupId;
 
    }
 
-   public String getTraceId()
-   {
+   public String getTraceId() {
       return this.traceId;
    }
 
-   public void setTraceId(String traceId)
-   {
+   public void setTraceId(String traceId) {
       this.traceId = traceId;
    }
 
-   public ITraceLink<TLinkData> getHeadLink()
-   {
+   public ITraceLink<TLinkData> getHeadLink() {
       return this.headLink;
    }
 
-   public void setHeadLink(ITraceLink<TLinkData> headLink)
-   {
+   public void setHeadLink(ITraceLink<TLinkData> headLink) {
       this.headLink = headLink;
    }
 
-   public Date getUpdatedAt()
-   {
+   public Date getUpdatedAt() {
       return this.updatedAt;
    }
 
-   public void setUpdatedAt(Date updatedAt)
-   {
+   public void setUpdatedAt(Date updatedAt) {
       this.updatedAt = updatedAt;
    }
 
-   public Account getUpdatedBy()
-   {
+   public Account getUpdatedBy() {
       return this.updatedBy;
    }
 
-   public void setUpdatedBy(Account updatedBy)
-   {
+   public void setUpdatedBy(Account updatedBy) {
       this.updatedBy = updatedBy;
    }
 
-   public TState getData()
-   {
+   public TState getData() {
       return this.data;
    }
 
-   public void setData(TState data)
-   {
+   public void setData(TState data) {
       this.data = data;
    }
 
-   public String[] getTags()
-   {
+   public String[] getTags() {
       return tags;
    }
 
-   public void setTags(String[] tags)
-   {
+   public void setTags(String[] tags) {
       this.tags = tags;
    }
 
-   @Override
-   public String toString()
-   {
-      return "TraceState [traceId=" + traceId + ", headLink=" + headLink + ", updatedAt=" + updatedAt + ", updatedBy=" + updatedBy + ", data=" + data
-         + ", tags=" + Arrays.toString(tags) + "]";
+   public String getUpdatedByGroupId() {
+      return this.updatedByGroupId;
    }
 
-   
+   public void setUpdatedByGroupId(String updatedByGroupId) {
+      this.updatedByGroupId = updatedByGroupId;
+   }
+
+   @Override
+   public String toString() {
+      return "TraceState [traceId=" + traceId + ", headLink=" + headLink + ", updatedAt=" + updatedAt + ", updatedBy="
+            + updatedBy + ", data=" + data + ", tags=" + Arrays.toString(tags) + "]";
+   }
+
 }

--- a/src/main/java/com/stratumn/sdk/model/trace/TransferResponseInput.java
+++ b/src/main/java/com/stratumn/sdk/model/trace/TransferResponseInput.java
@@ -17,31 +17,35 @@ package com.stratumn.sdk.model.trace;
 
 import com.stratumn.sdk.TraceLink;
 
-public class TransferResponseInput<TLinkData> extends ParentLink<TLinkData>
-{
+public class TransferResponseInput<TLinkData> extends ParentLink<TLinkData> {
 
    private TLinkData data;
+   private String groupLabel;
 
-   public TransferResponseInput( TLinkData data ,String traceId)
-   {
+   public TransferResponseInput(TLinkData data, String traceId) {
       super(traceId);
       this.data = data;
    }
-   
-   public TransferResponseInput( TLinkData data, TraceLink<TLinkData> prevLink)
-   {
-      super( prevLink);
+
+   public TransferResponseInput(TLinkData data, TraceLink<TLinkData> prevLink) {
+      super(prevLink);
       this.data = data;
    }
 
-   public TLinkData getData()
-   {
+   public TLinkData getData() {
       return this.data;
    }
 
-   public void setData(TLinkData data)
-   {
+   public void setData(TLinkData data) {
       this.data = data;
+   }
+
+   public String getGroupLabel() {
+      return this.groupLabel;
+   }
+
+   public void setGroupLabel(String groupLabel) {
+      this.groupLabel = groupLabel;
    }
 
 }

--- a/src/main/resources/graphql/Fragments/TraceState.graphql
+++ b/src/main/resources/graphql/Fragments/TraceState.graphql
@@ -1,18 +1,19 @@
- fragment TraceStateFragment on Trace {
-        updatedAt
-        state {
-          data
-        }
-        head {
-          raw
-          data
-        }
-        # TODO: temporary, remove once state computation
-        # is handled server side
-        links {
-          nodes {
-            raw
-            data
-          }
-        }
-      }
+fragment TraceStateFragment on Trace {
+  updatedAt
+  state {
+    data
+  }
+  head {
+    raw
+    data
+    groupId
+  }
+  # TODO: temporary, remove once state computation
+  # is handled server side
+  links {
+    nodes {
+      raw
+      data
+    }
+  }
+}

--- a/src/main/resources/graphql/Queries/Config.graphql
+++ b/src/main/resources/graphql/Queries/Config.graphql
@@ -29,6 +29,7 @@ query ConfigQuery($workflowId: BigInt!) {
     groups {
       nodes {
         groupId: rowId
+        label
         members {
           nodes {
             accountId

--- a/src/test/java/com/stratumn/sdk/TestSdk.java
+++ b/src/test/java/com/stratumn/sdk/TestSdk.java
@@ -263,11 +263,13 @@ public class TestSdk {
    public void pushTraceTest() {
       try {
          newTraceTest();
+         Sdk<Object> sdk = getSdk();
+         sdk.withGroupLabel(MY_GROUP);
          assertNotNull(someTraceState);
          PushTransferInput<Object> push = new PushTransferInput<Object>(OTHER_GROUP, new Object(),
                someTraceState.getTraceId());
 
-         someTraceState = getSdk().pushTrace(push);
+         someTraceState = sdk.pushTrace(push);
          // System.out.println("test pushTrace " + gson.toJson(someTraceState));
          assertNotNull(push.getTraceId());
       } catch (Exception ex) {
@@ -281,7 +283,9 @@ public class TestSdk {
       try {
          pushTraceTest();
          TransferResponseInput<Object> trInput = new TransferResponseInput<Object>(null, someTraceState.getTraceId());
-         TraceState<Object, Object> stateAccept = getOtherGroupSdk().acceptTransfer(trInput);
+         Sdk<Object> sdk = getOtherGroupSdk();
+         sdk.withGroupLabel(MY_GROUP);
+         TraceState<Object, Object> stateAccept = sdk.acceptTransfer(trInput);
          // System.out.println("Accept Transfer:" + "\r\n" + stateAccept);
          assertNotNull(stateAccept.getTraceId());
       } catch (Exception ex) {
@@ -432,14 +436,15 @@ public class TestSdk {
       assertNotNull(someTraceState);
       assertEquals(someTraceState.getUpdatedByGroupId(), MY_GROUP);
       try {
-         // change group for action
-         sdk.withGroupLabel(OTHER_GROUP_LABEL);
+         Sdk<Object> sdk = getSdk();
          // Appendlink
          Map<String, Object> dataMap = new HashMap<String, Object>();
          dataMap.put("comment", "commment");
          // comment action
          AppendLinkInput<Object> appLinkInput = new AppendLinkInput<Object>(COMMENT_ACTION_KEY, dataMap,
                someTraceState.getTraceId());
+         // change group for action
+         appLinkInput.setGroupLabel(OTHER_GROUP_LABEL);
 
          TraceState<Object, Object> state = sdk.appendLink(appLinkInput);
          assertEquals(state.getUpdatedByGroupId(), OTHER_GROUP);

--- a/src/test/java/com/stratumn/sdk/TestSdk.java
+++ b/src/test/java/com/stratumn/sdk/TestSdk.java
@@ -264,7 +264,7 @@ public class TestSdk {
       try {
          newTraceTest();
          Sdk<Object> sdk = getSdk();
-         sdk.withGroupLabel(MY_GROUP);
+         sdk.withGroupLabel(MY_GROUP_LABEL);
          assertNotNull(someTraceState);
          PushTransferInput<Object> push = new PushTransferInput<Object>(OTHER_GROUP, new Object(),
                someTraceState.getTraceId());
@@ -284,7 +284,7 @@ public class TestSdk {
          pushTraceTest();
          TransferResponseInput<Object> trInput = new TransferResponseInput<Object>(null, someTraceState.getTraceId());
          Sdk<Object> sdk = getOtherGroupSdk();
-         sdk.withGroupLabel(MY_GROUP);
+         sdk.withGroupLabel(MY_GROUP_LABEL);
          TraceState<Object, Object> stateAccept = sdk.acceptTransfer(trInput);
          // System.out.println("Accept Transfer:" + "\r\n" + stateAccept);
          assertNotNull(stateAccept.getTraceId());

--- a/src/test/java/com/stratumn/sdk/TestSdk.java
+++ b/src/test/java/com/stratumn/sdk/TestSdk.java
@@ -1,12 +1,9 @@
 /*
 Copyright 2017 Stratumn SAS. All rights reserved.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,48 +54,12 @@ import com.stratumn.sdk.model.trace.TraceState;
 import com.stratumn.sdk.model.trace.TracesState;
 import com.stratumn.sdk.model.trace.TransferResponseInput;
 
-//used the same structure so its compatable with existing links
-class SomeClass {
-   public int weight;
-   public boolean valid;
-   public String[] operators;
-   public String operation;
-   public Identifiable certificate;
-   public Identifiable certificate2;
-   public Identifiable[] certificates;
-}
-
-class StateExample {
-   public String f1;
-   public SomeClass data;
-
-}
-
-class ReasonClass {
-   public String reason;
-}
-
-class OperationClass {
-   public String operation;
-   public String destination;
-   public String eta;
-}
-
-class Step {
-
-   public StepData data;
-}
-
-class StepData {
-   public Identifiable[] stp_form_section;
-}
-
-public class TestSdkPojo {
+public class TestSdk {
 
    private static Gson gson = JsonHelper.getGson();
-   private static final String ACCOUNT_STAGING_URL = "https://account-api.staging.stratumn.com";
-   private static final String TRACE_STAGING_URL = "https://trace-api.staging.stratumn.com";
-   private static final String MEDIA_STAGING_URL = "https://media-api.staging.stratumn.com";
+   private static final String ACCOUNT_RELEASE_URL = "https://account-api.staging.stratumn.com";
+   private static final String TRACE_RELEASE_URL = "https://trace-api.staging.stratumn.com";
+   private static final String MEDIA_RELEASE_URL = "https://media-api.staging.stratumn.com";
 
    private static String PEM_PRIVATEKEY = "-----BEGIN ED25519 PRIVATE KEY-----\nMFACAQAwBwYDK2VwBQAEQgRAjgtjpc1iOR4zYm+21McRGoWr0WM1NBkm26uZmFAx\n853QZ8CRL/HWGCPpEt18JrHZr9ZwA9UyoEosPR8gPakZFQ==\n-----END ED25519 PRIVATE KEY-----\n";
    private static String WORFKLOW_ID = "591";
@@ -110,31 +72,32 @@ public class TestSdkPojo {
    private static String OTHER_GROUP = "1785";
    private static String OTHER_GROUP_LABEL = "stp";
 
-   private static Sdk<StateExample> sdk;
-   private static Sdk<StateExample> otherSdk;
+   private static Sdk<Object> sdk;
+   private static Sdk<Object> otherSdk;
 
-   public static Sdk<StateExample> getSdk() {
+   public static Sdk<Object> getSdk() {
 
       if (sdk == null) {
          Secret s = Secret.newPrivateKeySecret(PEM_PRIVATEKEY);
          SdkOptions opts = new SdkOptions(WORFKLOW_ID, s);
-         opts.setEndpoints(new Endpoints(ACCOUNT_STAGING_URL, TRACE_STAGING_URL, MEDIA_STAGING_URL));
+         opts.setEndpoints(new Endpoints(ACCOUNT_RELEASE_URL, TRACE_RELEASE_URL, MEDIA_RELEASE_URL));
          opts.setEnableDebuging(true);
          opts.setGroupLabel(MY_GROUP_LABEL);
-         sdk = new Sdk<StateExample>(opts, StateExample.class);
+         sdk = new Sdk<Object>(opts);
+
       }
       return sdk;
    }
 
-   public static Sdk<StateExample> getOtherGroupSdk() {
+   public static Sdk<Object> getOtherGroupSdk() {
 
       if (otherSdk == null) {
          Secret s = Secret.newPrivateKeySecret(PEM_PRIVATEKEY_2);
          SdkOptions opts = new SdkOptions(WORFKLOW_ID, s);
-         opts.setEndpoints(new Endpoints(ACCOUNT_STAGING_URL, TRACE_STAGING_URL, MEDIA_STAGING_URL));
+         opts.setEndpoints(new Endpoints(ACCOUNT_RELEASE_URL, TRACE_RELEASE_URL, MEDIA_RELEASE_URL));
          opts.setEnableDebuging(true);
          opts.setGroupLabel(OTHER_GROUP_LABEL);
-         otherSdk = new Sdk<StateExample>(opts);
+         otherSdk = new Sdk<Object>(opts);
 
       }
       return otherSdk;
@@ -143,8 +106,8 @@ public class TestSdkPojo {
    @Test
    public void getTraceDetailsTest() {
       try {
-         Sdk<StateExample> sdk = getSdk();
-         String traceId = "18014bb9-1c3c-402f-91f8-5cab2c23b292";
+         Sdk<Object> sdk = getSdk();
+         String traceId = "191516ec-5f8c-4757-9061-8c7ab06cf0a0";
          GetTraceDetailsInput input = new GetTraceDetailsInput(traceId, 5, null, null, null);
 
          TraceDetails<Object> details = sdk.getTraceDetails(input);
@@ -161,11 +124,12 @@ public class TestSdkPojo {
    @Test
    public void getTraceStateTest() {
       try {
-         Sdk<StateExample> sdk = getSdk();
+         Sdk<Object> sdk = getSdk();
          String traceId = "191516ec-5f8c-4757-9061-8c7ab06cf0a0";
          GetTraceStateInput input = new GetTraceStateInput(traceId);
-         TraceState<StateExample, SomeClass> state = sdk.getTraceState(input);
-         // // System.out.println("testTraceState" + gson.toJson(state));
+         TraceState<Object, Object> state = sdk.getTraceState(input);
+         System.out.println("testTraceState" + gson.toJson(state));
+         assertTrue(state.getTraceId().equals(traceId));
          assertTrue(state.getTraceId().equals(traceId));
          assertFalse(gson.toJson(state).contains("Error"));
       } catch (Exception ex) {
@@ -177,9 +141,9 @@ public class TestSdkPojo {
    @Test
    public void getIncomingTracesTest() {
       try {
-         Sdk<StateExample> sdk = getSdk();
+         Sdk<Object> sdk = getSdk();
          PaginationInfo paginationInfo = new PaginationInfo(10, null, null, null);
-         TracesState<StateExample, SomeClass> state = sdk.getIncomingTraces(paginationInfo);
+         TracesState<Object, Object> state = sdk.getIncomingTraces(paginationInfo);
          // System.out.println("testIncomingTraces " + gson.toJson(state));
          assertFalse(gson.toJson(state).contains("Error"));
       } catch (Exception ex) {
@@ -191,9 +155,9 @@ public class TestSdkPojo {
    @Test
    public void getOutoingTracesTest() {
       try {
-         Sdk<StateExample> sdk = getSdk();
+         Sdk<Object> sdk = getSdk();
          PaginationInfo paginationInfo = new PaginationInfo(10, null, null, null);
-         TracesState<StateExample, SomeClass> state = sdk.getOutgoingTraces(paginationInfo);
+         TracesState<Object, Object> state = sdk.getOutgoingTraces(paginationInfo);
          // System.out.println("testOutoingTraces " + gson.toJson(state));
          assertFalse(gson.toJson(state).contains("Error"));
       } catch (Exception ex) {
@@ -205,9 +169,9 @@ public class TestSdkPojo {
    @Test
    public void getAttestationTracesTest() {
       try {
-         Sdk<StateExample> sdk = getSdk();
+         Sdk<Object> sdk = getSdk();
          PaginationInfo paginationInfo = new PaginationInfo(10, null, null, null);
-         TracesState<StateExample, SomeClass> state = sdk.getAttestationTraces(ACTION_KEY, paginationInfo);
+         TracesState<Object, Object> state = sdk.getAttestationTraces(ACTION_KEY, paginationInfo);
          // System.out.println("testBacklog " + gson.toJson(state));
          assertFalse(gson.toJson(state).contains("Error"));
       } catch (Exception ex) {
@@ -219,9 +183,9 @@ public class TestSdkPojo {
    @Test
    public void getBacklogTracesTest() {
       try {
-         Sdk<StateExample> sdk = getSdk();
+         Sdk<Object> sdk = getSdk();
          PaginationInfo paginationInfo = new PaginationInfo(10, null, null, null);
-         TracesState<StateExample, SomeClass> state = sdk.getBacklogTraces(paginationInfo);
+         TracesState<Object, Object> state = sdk.getBacklogTraces(paginationInfo);
          // System.out.println("testBacklog " + gson.toJson(state));
          assertFalse(gson.toJson(state).contains("Error"));
       } catch (Exception ex) {
@@ -231,25 +195,19 @@ public class TestSdkPojo {
    }
 
    // used to pass the trace from one test method to another
-   private TraceState<StateExample, SomeClass> someTraceState;
-   private TraceState<StateExample, Step> uploadState;
+   private TraceState<Object, Object> someTraceState;
 
-   @Test
    public void newTraceTest() {
       try {
-         Sdk<StateExample> sdk = getSdk();
-         Map<String, Object> dataMap = new HashMap<String, Object>();
-         dataMap.put("weight", "123");
-         dataMap.put("valid", true);
-         dataMap.put("operators", new String[] { "1", "2" });
-         dataMap.put("operation", "my new operation 1");
-         // quickly convert existing map to object but the object can be created any way
-         SomeClass data = JsonHelper.mapToObject(dataMap, SomeClass.class);
-         NewTraceInput<SomeClass> newTraceInput = new NewTraceInput<SomeClass>(ACTION_KEY, data);
-
-         TraceState<StateExample, SomeClass> state = sdk.newTrace(newTraceInput);
+         Sdk<Object> sdk = getSdk();
+         Map<String, Object> data = new HashMap<String, Object>();
+         data.put("weight", "123");
+         data.put("valid", true);
+         data.put("operators", new String[] { "1", "2" });
+         data.put("operation", "my new operation 1");
+         NewTraceInput<Object> newTraceInput = new NewTraceInput<Object>(ACTION_KEY, data);
+         TraceState<Object, Object> state = sdk.newTrace(newTraceInput);
          assertNotNull(state.getTraceId());
-         assertTrue(state.getData() instanceof StateExample);
          someTraceState = state;
       } catch (Exception ex) {
          ex.printStackTrace();
@@ -260,20 +218,23 @@ public class TestSdkPojo {
    @Test
    public void newTraceUploadTest() {
       try {
-         Sdk<StateExample> sdk = getSdk();
+         Sdk<Object> sdk = getSdk();
+         Map<String, Object> data = new HashMap<String, Object>();
+         data.put("weight", "123");
+         data.put("valid", true);
+         data.put("operators", new String[] { "1", "2" });
+         data.put("operation", "my new operation 1");
+         // data.put("Certificate" ,
+         // FileWrapper.fromFilePath(Paths.get("src/test/resources/stratumn.png")));
+         data.put("Certificate2", FileWrapper.fromFilePath(Paths.get("src/test/resources/rapport.pdf")));
+         data.put("Certificates",
+               new Identifiable[] { FileWrapper.fromFilePath(Paths.get("src/test/resources/TestFileX.txt")) });
 
-         // Step s = new Step();
-         StepData s = new StepData();
+         NewTraceInput<Object> newTraceInput = new NewTraceInput<Object>(ACTION_KEY, data);
 
-         // This fails on Identifiable deserialzation
-         s.stp_form_section = new Identifiable[] {
-               FileWrapper.fromFilePath(Paths.get("src/test/resources/TestFileX.txt")) };
-
-         NewTraceInput<StepData> newTraceInput = new NewTraceInput<StepData>(ACTION_KEY, s);
-
-         TraceState<StateExample, StepData> state = sdk.newTrace(newTraceInput);
+         TraceState<Object, Object> state = sdk.newTrace(newTraceInput);
          assertNotNull(state.getTraceId());
-
+         someTraceState = state;
       } catch (Exception ex) {
          ex.printStackTrace();
          fail(ex.getMessage());
@@ -285,13 +246,13 @@ public class TestSdkPojo {
       try {
          newTraceTest();
          assertNotNull(someTraceState);
-         OperationClass data;
+         Map<String, Object> data;
          String json = "{ operation: \"XYZ shipment departed port for ABC\"," + "    destination: \"ABC\", "
                + "    customsCheck: true, " + "    eta: \"2019-07-02T12:00:00.000Z\"" + "  }";
-         data = JsonHelper.objectToObject(json, OperationClass.class);
-         AppendLinkInput<OperationClass> appLinkInput = new AppendLinkInput<OperationClass>(ACTION_KEY, data,
+         data = JsonHelper.objectToMap(json);
+         AppendLinkInput<Object> appLinkInput = new AppendLinkInput<Object>(ACTION_KEY, data,
                someTraceState.getTraceId());
-         TraceState<StateExample, OperationClass> state = getSdk().appendLink(appLinkInput);
+         TraceState<Object, Object> state = getSdk().appendLink(appLinkInput);
          assertNotNull(state.getTraceId());
       } catch (Exception ex) {
          fail(ex.getMessage());
@@ -306,7 +267,7 @@ public class TestSdkPojo {
          PushTransferInput<Object> push = new PushTransferInput<Object>(OTHER_GROUP, new Object(),
                someTraceState.getTraceId());
 
-         getSdk().pushTrace(push);
+         someTraceState = getSdk().pushTrace(push);
          // System.out.println("test pushTrace " + gson.toJson(someTraceState));
          assertNotNull(push.getTraceId());
       } catch (Exception ex) {
@@ -318,17 +279,10 @@ public class TestSdkPojo {
    @Test
    public void acceptTransferTest() {
       try {
-         PaginationInfo paginationInfo = new PaginationInfo(10, null, null, null);
-         TracesState<StateExample, SomeClass> tracesIn = getSdk().getIncomingTraces(paginationInfo);
-
-         if (tracesIn.getTotalCount() == 0) {
-            pushTraceTest();
-         } else {
-            someTraceState = tracesIn.getTraces().get(0);
-         }
-         TransferResponseInput<SomeClass> trInput = new TransferResponseInput<SomeClass>(null,
-               someTraceState.getTraceId());
-         TraceState<StateExample, SomeClass> stateAccept = getOtherGroupSdk().acceptTransfer(trInput);
+         pushTraceTest();
+         TransferResponseInput<Object> trInput = new TransferResponseInput<Object>(null, someTraceState.getTraceId());
+         TraceState<Object, Object> stateAccept = getOtherGroupSdk().acceptTransfer(trInput);
+         // System.out.println("Accept Transfer:" + "\r\n" + stateAccept);
          assertNotNull(stateAccept.getTraceId());
       } catch (Exception ex) {
          ex.printStackTrace();
@@ -340,7 +294,7 @@ public class TestSdkPojo {
    public void rejectTransferTest() {
       try {
          PaginationInfo paginationInfo = new PaginationInfo(10, null, null, null);
-         TracesState<StateExample, SomeClass> tracesIn = getSdk().getIncomingTraces(paginationInfo);
+         TracesState<Object, Object> tracesIn = getSdk().getIncomingTraces(paginationInfo);
 
          String traceId = null;
          if (tracesIn.getTotalCount() == 0) {
@@ -350,8 +304,8 @@ public class TestSdkPojo {
             someTraceState = tracesIn.getTraces().get(0);
             traceId = someTraceState.getTraceId();
          }
-         TransferResponseInput<SomeClass> trInput = new TransferResponseInput<SomeClass>(null, traceId);
-         TraceState<StateExample, SomeClass> stateReject = getOtherGroupSdk().rejectTransfer(trInput);
+         TransferResponseInput<Object> trInput = new TransferResponseInput<Object>(null, traceId);
+         TraceState<Object, Object> stateReject = getOtherGroupSdk().rejectTransfer(trInput);
          // System.out.println("Reject Transfer:" + "\r\n" + stateReject);
          assertNotNull(stateReject.getTraceId());
       } catch (Exception ex) {
@@ -364,9 +318,9 @@ public class TestSdkPojo {
    public void cancelTransferTest() {
       try {
          pushTraceTest();
-         TransferResponseInput<SomeClass> responseInput = new TransferResponseInput<SomeClass>(null,
+         TransferResponseInput<Object> responseInput = new TransferResponseInput<Object>(null,
                someTraceState.getTraceId());
-         TraceState<StateExample, SomeClass> statecancel = sdk.cancelTransfer(responseInput);
+         TraceState<Object, Object> statecancel = sdk.cancelTransfer(responseInput);
          // System.out.println("cancelTransfer:" + "\r\n" + statecancel);
          assertNotNull(statecancel.getTraceId());
       } catch (Exception ex) {
@@ -378,12 +332,12 @@ public class TestSdkPojo {
    @Test
    public void downloadFilesInObjectTest() {
       try {
-         TraceState<StateExample, Step> state;
+         TraceState<Object, Object> state;
          try {
-            state = getSdk().getTraceState(new GetTraceStateInput("9565be68-5a11-4262-9a55-bd3fe6bfa3f0"));
+            state = getSdk().getTraceState(new GetTraceStateInput("9e8b9094-08aa-447d-87b9-a764db26b646"));
          } catch (Exception e) { // trace not found
             newTraceUploadTest();
-            state = uploadState;
+            state = someTraceState;
          }
 
          Object dataWithRecords = state.getHeadLink().formData();
@@ -412,14 +366,14 @@ public class TestSdkPojo {
          input.setTraceId(traceId);
          input.setTags(new String[] { randomUUIDString });
 
-         TraceState<StateExample, SomeClass> t = getSdk().addTagsToTrace(input);
+         TraceState<Object, Object> t = getSdk().addTagsToTrace(input);
          assertEquals(traceId, t.getTraceId());
 
          // search the trace by tags
          List<String> tags = new ArrayList<String>();
          tags.add(randomUUIDString);
          SearchTracesFilter f = new SearchTracesFilter(tags);
-         TracesState<StateExample, SomeClass> res = sdk.searchTraces(f, new PaginationInfo());
+         TracesState<Object, Object> res = sdk.searchTraces(f, new PaginationInfo());
 
          assertEquals(1, res.getTotalCount());
          assertEquals(traceId, res.getTraces().get(0).getTraceId());
@@ -440,7 +394,7 @@ public class TestSdkPojo {
          SearchTracesFilter f = new SearchTracesFilter();
          f.setTags(tags);
          f.setSearchType(SearchTracesFilter.SEARCH_TYPE.TAGS_CONTAINS);
-         TracesState<StateExample, SomeClass> res = getSdk().searchTraces(f, new PaginationInfo());
+         TracesState<Object, Object> res = getSdk().searchTraces(f, new PaginationInfo());
          assertEquals(1, res.getTotalCount());
          assertEquals("5bf6d482-cfdc-4edc-a5ef-c96539da94d8", res.getTraces().get(0).getTraceId());
       } catch (Exception ex) {
@@ -449,12 +403,6 @@ public class TestSdkPojo {
       }
    }
 
-   /***
-    * Writes the files to the output folder
-    * 
-    * @param fWrapper
-    * @throws TraceSdkException
-    */
    private void writeFileToDisk(FileWrapper fWrapper) throws TraceSdkException {
 
       ByteBuffer buffer = fWrapper.decryptedData();
@@ -484,20 +432,20 @@ public class TestSdkPojo {
       assertNotNull(someTraceState);
       assertEquals(someTraceState.getUpdatedByGroupId(), MY_GROUP);
       try {
-         // change group for action for group2
+         // change group for action
          sdk.withGroupLabel(OTHER_GROUP_LABEL);
          // Appendlink
          Map<String, Object> dataMap = new HashMap<String, Object>();
          dataMap.put("comment", "commment");
-         AppendLinkInput<Map<String, Object>> appLinkInput = new AppendLinkInput<Map<String, Object>>(
-               COMMENT_ACTION_KEY, dataMap, someTraceState.getTraceId());
+         // comment action
+         AppendLinkInput<Object> appLinkInput = new AppendLinkInput<Object>(COMMENT_ACTION_KEY, dataMap,
+               someTraceState.getTraceId());
 
-         TraceState<StateExample, Map<String, Object>> state = sdk.appendLink(appLinkInput);
-         // should equal group2 id
+         TraceState<Object, Object> state = sdk.appendLink(appLinkInput);
          assertEquals(state.getUpdatedByGroupId(), OTHER_GROUP);
 
-         AppendLinkInput<Map<String, Object>> appLinkInputWithGroupLabel = new AppendLinkInput<Map<String, Object>>(
-               COMMENT_ACTION_KEY, dataMap, someTraceState.getTraceId());
+         AppendLinkInput<Object> appLinkInputWithGroupLabel = new AppendLinkInput<Object>(COMMENT_ACTION_KEY, dataMap,
+               someTraceState.getTraceId());
          appLinkInputWithGroupLabel.setGroupLabel(MY_GROUP_LABEL);
 
          state = sdk.appendLink(appLinkInputWithGroupLabel);
@@ -507,6 +455,70 @@ public class TestSdkPojo {
          e.printStackTrace();
          fail(e.getMessage());
       }
+
+   }
+
+   public static void main(String[] args) throws Exception {
+      Sdk<Object> sdk = getSdk();
+
+      Map<String, Object> data;
+      String json = "{  operation:\"new shipment XYZ for ABC\"," + "    weight: 123," + "    valid: true,"
+            + "    operators: [\"Ludovic K.\", \"Bernard Q.\"]" + "  }";
+      data = JsonHelper.objectToMap(json);
+      NewTraceInput<Object> newTraceInput = new NewTraceInput<Object>(ACTION_KEY, data);
+      TraceState<Object, Object> newState = sdk.newTrace(newTraceInput);
+      // System.out.println("newTrace:" + "\r\n" + newState);
+
+      PaginationInfo paginationInfo = new PaginationInfo(10, null, null, null);
+      TracesState<Object, Object> tracesIn = sdk.getIncomingTraces(paginationInfo);
+      // System.out.println("getIncomingTraces:" + "\r\n" + tracesIn);
+
+      paginationInfo = new PaginationInfo(10, null, null, null);
+      TracesState<Object, Object> tracesOut = sdk.getOutgoingTraces(paginationInfo);
+      // System.out.println("getOutgoingTraces:" + "\r\n" + tracesOut);
+
+      paginationInfo = new PaginationInfo(10, null, null, null);
+      TracesState<Object, Object> tracesBlog = sdk.getBacklogTraces(paginationInfo);
+      // System.out.println("getBacklogTraces:" + "\r\n" + tracesBlog);
+
+      paginationInfo = new PaginationInfo(10, null, null, null);
+      TracesState<Object, Object> tracesAtt = sdk.getAttestationTraces(ACTION_KEY, paginationInfo);
+      // System.out.println("getAttestationTraces:" + "\r\n" + tracesAtt);
+
+      // append link
+      json = "{ operation: \"XYZ shipment departed port for ABC\"," + "    destination: \"ABC\", "
+            + "    customsCheck: true, " + "    eta: \"2019-07-02T12:00:00.000Z\"" + "  }";
+      data = JsonHelper.objectToMap(json);
+      AppendLinkInput<Object> appLinkInput = new AppendLinkInput<Object>(ACTION_KEY, data, newState.getTraceId());
+      TraceState<Object, Object> state = sdk.appendLink(appLinkInput);
+      // System.out.println("appendLink:" + "\r\n" + state);
+
+      // push to cancel
+      PushTransferInput<Object> push = new PushTransferInput<Object>(OTHER_GROUP, new Object(), state.getTraceId());
+      TraceState<Object, Object> statepsh = sdk.pushTrace(push);
+
+      // System.out.println("pushTrace:" + "\r\n" + statepsh);
+
+      TransferResponseInput<Object> responseInput = new TransferResponseInput<Object>(null, statepsh.getTraceId());
+      TraceState<Object, Object> statecancel = sdk.cancelTransfer(responseInput);
+      // System.out.println("cancelTransfer:" + "\r\n" + statecancel);
+
+      // push to accept
+      push = new PushTransferInput<Object>(OTHER_GROUP, new Object(), state.getTraceId());
+      statepsh = sdk.pushTrace(push);
+
+      responseInput = new TransferResponseInput<Object>(null, statepsh.getTraceId());
+      TraceState<Object, Object> stateAccept = sdk.acceptTransfer(responseInput);
+      // System.out.println("acceptTransfer:" + "\r\n" + stateAccept);
+
+      // push to reject then pull
+      push = new PushTransferInput<Object>(OTHER_GROUP, new Object(), state.getTraceId());
+      statepsh = sdk.pushTrace(push);
+
+      data = new HashMap<String, Object>(Collections.singletonMap("why", "No way!"));
+      responseInput = new TransferResponseInput<Object>(null, statepsh.getTraceId());
+      TraceState<Object, Object> stateReject = sdk.rejectTransfer(responseInput);
+      // System.out.println("acceptTransfer:" + "\r\n" + stateReject);
 
    }
 

--- a/src/test/java/com/stratumn/sdk/TestSdkPojo.java
+++ b/src/test/java/com/stratumn/sdk/TestSdkPojo.java
@@ -484,13 +484,14 @@ public class TestSdkPojo {
       assertNotNull(someTraceState);
       assertEquals(someTraceState.getUpdatedByGroupId(), MY_GROUP);
       try {
-         // change group for action for group2
-         sdk.withGroupLabel(OTHER_GROUP_LABEL);
+         Sdk<StateExample> sdk = getSdk();
          // Appendlink
          Map<String, Object> dataMap = new HashMap<String, Object>();
          dataMap.put("comment", "commment");
          AppendLinkInput<Map<String, Object>> appLinkInput = new AppendLinkInput<Map<String, Object>>(
                COMMENT_ACTION_KEY, dataMap, someTraceState.getTraceId());
+         // change group for action
+         appLinkInput.setGroupLabel(OTHER_GROUP_LABEL);
 
          TraceState<StateExample, Map<String, Object>> state = sdk.appendLink(appLinkInput);
          // should equal group2 id


### PR DESCRIPTION
- Added the "groupLabel" in classes when it was possible
- Added the "groupLabel" in the SDK's options to make it a default value
- Restore the old test without pojo

I noticed that since the change on the api for accounts, we don't get the "createdBy" value anymore in the trace state, as it is now "createdByAccountId" => should we add a retro compatibility ?

Let me know if it seems ok to you.

If it is ok for you, I will also update the documentation according to this change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-java/25)
<!-- Reviewable:end -->
