### PR TITLE
fix version in readme; fix push to git on release

### DIFF
--- a/.semaphore/maven-release.yml
+++ b/.semaphore/maven-release.yml
@@ -15,7 +15,7 @@ blocks:
         - name: github-write
       env_vars:
         - name: MAVEN_OPTS
-          value: "-Dmaven.repo.local=.m2"
+          value: '-Dmaven.repo.local=.m2'
       prologue:
         commands:
           - checkout
@@ -29,5 +29,4 @@ blocks:
             - mvn --batch-mode release:prepare
             - mvn -Dmaven.test.skip=true release:perform
             # the release creates commits with tags, we need to push them to github
-            - git push origin master
-
+            - git push -q https://${GH_TOKEN}@github.com/${SEMAPHORE_GIT_REPO_SLUG}.git master

--- a/README.md
+++ b/README.md
@@ -10,18 +10,9 @@ Required version : Java >= 8
 
 ### Maven
 
-The latest available version can be seen above.
+The latest available version along with installation information can be found [here](https://maven-badges.herokuapp.com/maven-central/com.stratumn/sdk).
 
 All versions can be seen [here](https://search.maven.org/artifact/com.stratumn/sdk).
-
-```xml
-<dependency>
-  <groupId>com.stratumn</groupId>
-  <artifactId>sdk</artifactId>
-  <version>VERSION</version>
-</dependency>
-```
-
 ## :rocket: Usage and Getting Started
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Stratumn SDK for Java
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.stratumn/sdk/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.stratumn/sdk)
+
 The official Stratumn SDK for Java to interact with [Trace](https://trace.stratumn.com).
 
 ## :satellite: Installing
@@ -8,11 +10,15 @@ Required version : Java >= 8
 
 ### Maven
 
+The latest available version can be seen above.
+
+All versions can be seen [here](https://search.maven.org/artifact/com.stratumn/sdk).
+
 ```xml
 <dependency>
   <groupId>com.stratumn</groupId>
   <artifactId>sdk</artifactId>
-  <version>0.2.2</version>
+  <version>VERSION</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Required version : Java >= 8
 The latest available version along with installation information can be found [here](https://maven-badges.herokuapp.com/maven-central/com.stratumn/sdk).
 
 All versions can be seen [here](https://search.maven.org/artifact/com.stratumn/sdk).
+
 ## :rocket: Usage and Getting Started
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Required version : Java >= 8
 <dependency>
   <groupId>com.stratumn</groupId>
   <artifactId>sdk</artifactId>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
 </dependency>
 ```
 


### PR DESCRIPTION
This should fix a problem where semaphore tries to push commits to master, with the semaphore provided github auth (used by all jobs just to checkout, READ ONLY) instead of the semaphore user we created to write to github.

It also updates the readme with the latest version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/sdk-java/27)
<!-- Reviewable:end -->
